### PR TITLE
Add Cursor and Grok harnesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,35 @@ ask checks for updates at most once a day. If a new version is available, it let
 
 ## How it works
 
-Under the hood, ask runs Codex, Claude Code, Pi, or OpenCode using the CLI already installed and logged in on your machine.
+Under the hood, ask runs Codex, Claude Code, Pi, OpenCode, Cursor, or Grok
+using the CLI already installed and logged in on your machine.
 
 For a new session, ask uses your default agent, model, and reasoning. Continuing a session restores those saved choices and the underlying agent session ID. Answer instructions come from the current global setting. Ask starts the selected CLI read-only in your current folder, prints the answer to stdout, and saves the turn automatically.
 
 ## Agents and models
 
 Run `ask --settings` to choose the default agent, model, reasoning, and answer instructions. Use `/settings` inside a session to change that session's model or reasoning, or to edit the global answer instructions. Start a new session to switch agents.
+
+| Agent | Binary | Read-only mode | Sessions |
+| --- | --- | --- | --- |
+| Codex | `codex` | Codex read-only sandbox | Saved thread IDs |
+| Claude Code | `claude` | `--permission-mode plan` | Saved session IDs |
+| OpenCode | `opencode` | Read-only tools | Saved session IDs |
+| Pi | `pi` | Read-only tools (`read,grep,find,ls`) | Saved session IDs |
+| Cursor | `cursor-agent` (falls back to `agent`) | Ask mode (`--mode ask`) | Saved chat IDs |
+| Grok | `grok` (also checks `~/.grok/bin/grok`) | Plan mode (`--permission-mode plan`) | Saved session IDs |
+
+Cursor and Grok use the CLIs installed by:
+
+```sh
+curl https://cursor.com/install -fsS | bash   # Cursor
+curl -fsSL https://x.ai/cli/install.sh | bash # Grok, then `grok login`
+```
+
+Both install a binary named `agent`; Cursor is `cursor-agent` (Grok is `grok`).
+ask always calls the unambiguous name, falling back to `agent` only for Cursor.
+Set `ASK_CURSOR_BIN` to pick a specific Cursor CLI (for example
+`cursor-work-agent`) and `ASK_GROK_BIN` for a different Grok binary.
 
 ## Contributing
 

--- a/src/harness/cursor.rs
+++ b/src/harness/cursor.rs
@@ -1,0 +1,366 @@
+use std::ffi::OsString;
+use std::io::{BufRead, BufReader, Read};
+use std::process::{Command, Stdio};
+
+use serde_json::Value;
+
+use super::{Harness, Model, Response, RunOptions};
+use crate::error::{Error, Result};
+
+pub(super) struct Cursor {
+    program: OsString,
+}
+
+impl Cursor {
+    pub(super) fn new(program: OsString) -> Self {
+        Self { program }
+    }
+
+    fn command(
+        &self,
+        question: &str,
+        session_id: Option<&str>,
+        options: &RunOptions<'_>,
+    ) -> Command {
+        let mut command = Command::new(&self.program);
+        command.args([
+            "-p",
+            "--mode",
+            "ask",
+            "--trust",
+            "--output-format",
+            "stream-json",
+            "--stream-partial-output",
+        ]);
+        if let Some(session_id) = session_id {
+            command.args(["--resume", session_id]);
+        }
+        if let Some(model) = options.model {
+            command.args(["--model", model]);
+        }
+        let prompt = match options.instructions {
+            Some(instructions) if !instructions.is_empty() => {
+                format!("{question}\n\n{instructions}")
+            }
+            _ => question.to_owned(),
+        };
+        command.arg(prompt);
+        command
+    }
+}
+
+impl Harness for Cursor {
+    fn models(&mut self) -> Result<Vec<Model>> {
+        let output = Command::new(&self.program)
+            .arg("models")
+            .output()
+            .map_err(start_error)?;
+        if !output.status.success() {
+            return Err(Error::agent(
+                "cursor",
+                format!(
+                    "could not list Cursor models: {}",
+                    String::from_utf8_lossy(&output.stderr).trim()
+                ),
+            ));
+        }
+        let output = String::from_utf8(output.stdout).map_err(|_| {
+            Error::agent(
+                "cursor",
+                "Cursor returned a model list that was not valid UTF-8",
+            )
+        })?;
+        parse_models(&output)
+    }
+
+    fn ask(
+        &mut self,
+        question: &str,
+        session_id: Option<&str>,
+        options: RunOptions<'_>,
+        on_delta: &mut dyn FnMut(&str) -> Result<()>,
+    ) -> Result<Response> {
+        let mut child = self
+            .command(question, session_id, &options)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(start_error)?;
+        let stdout = child.stdout.take().expect("piped stdout is available");
+        let mut stderr = child.stderr.take().expect("piped stderr is available");
+        let stderr_reader = std::thread::spawn(move || {
+            let mut output = Vec::new();
+            let _ = stderr.read_to_end(&mut output);
+            output
+        });
+
+        let result = read_events(BufReader::new(stdout), on_delta);
+        let status = child.wait().map_err(|error| {
+            Error::agent("cursor", format!("could not wait for Cursor: {error}"))
+        })?;
+        let stderr = stderr_reader
+            .join()
+            .map_err(|_| Error::agent("cursor", "could not read Cursor error output"))?;
+
+        if !status.success() && result.is_err() {
+            return Err(failure(status, &stderr));
+        }
+        result
+    }
+}
+
+fn start_error(error: std::io::Error) -> Error {
+    if error.kind() == std::io::ErrorKind::NotFound {
+        Error::new(
+            "Cursor is not installed or not on PATH",
+            "install it with 'curl https://cursor.com/install -fsS | bash' and run 'agent login'",
+        )
+    } else {
+        Error::agent("cursor", format!("could not start Cursor: {error}"))
+    }
+}
+
+fn failure(status: std::process::ExitStatus, stderr: &[u8]) -> Error {
+    let detail = String::from_utf8_lossy(stderr).trim().to_owned();
+    if detail.is_empty() {
+        Error::agent("cursor", format!("Cursor exited with {status}"))
+    } else {
+        Error::agent("cursor", format!("Cursor failed: {detail}"))
+    }
+}
+
+fn parse_models(output: &str) -> Result<Vec<Model>> {
+    let mut models = Vec::new();
+    for line in output.lines() {
+        let mut parts = line.splitn(2, " - ");
+        let Some(id) = parts.next() else { continue };
+        let Some(name) = parts.next() else { continue };
+        let id = id.trim();
+        if id.is_empty() {
+            continue;
+        }
+        let name = name.trim();
+        models.push(Model {
+            id: id.to_owned(),
+            name: name.replace(" (default)", "").to_owned(),
+            description: String::new(),
+            is_default: name.contains("(default)"),
+            reasoning: Vec::new(),
+            default_reasoning: None,
+        });
+    }
+
+    if models.is_empty() {
+        Err(Error::agent(
+            "cursor",
+            "Cursor did not report any available models",
+        ))
+    } else {
+        Ok(models)
+    }
+}
+
+fn read_events(
+    reader: impl BufRead,
+    on_delta: &mut dyn FnMut(&str) -> Result<()>,
+) -> Result<Response> {
+    let mut streamed_answer = String::new();
+    let mut final_answer = None;
+    let mut session_id = None;
+    let mut reported_error = None;
+
+    for line in reader.lines() {
+        let line = line.map_err(|error| {
+            Error::agent("cursor", format!("could not read Cursor response: {error}"))
+        })?;
+        let event: Value = serde_json::from_str(&line).map_err(|error| {
+            Error::agent(
+                "cursor",
+                format!("could not parse Cursor response: {error}"),
+            )
+        })?;
+        match event.get("type").and_then(Value::as_str) {
+            Some("assistant") => {
+                let text = message_text(&event);
+                if event.get("timestamp_ms").is_some() {
+                    if let Some(text) = &text {
+                        streamed_answer.push_str(text);
+                        on_delta(text)?;
+                    }
+                } else if let Some(text) = text {
+                    final_answer = Some(text);
+                }
+            }
+            Some("result") => {
+                session_id = event
+                    .get("session_id")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned);
+                if event.get("is_error").and_then(Value::as_bool) == Some(true) {
+                    reported_error = Some(
+                        event
+                            .get("result")
+                            .and_then(Value::as_str)
+                            .unwrap_or("unknown error")
+                            .to_owned(),
+                    );
+                } else if final_answer.is_none() {
+                    final_answer = event
+                        .get("result")
+                        .and_then(Value::as_str)
+                        .map(str::to_owned);
+                }
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    if let Some(error) = reported_error {
+        return Err(Error::agent(
+            "cursor",
+            format!("Cursor reported an error: {error}"),
+        ));
+    }
+    Ok(Response {
+        answer: final_answer.unwrap_or(streamed_answer),
+        session_id: session_id.ok_or_else(|| {
+            Error::agent("cursor", "Cursor completed without returning a session ID")
+        })?,
+    })
+}
+
+fn message_text(event: &Value) -> Option<String> {
+    let content = event["message"]["content"].as_array()?;
+    let text = content
+        .iter()
+        .filter(|block| block["type"].as_str() == Some("text"))
+        .filter_map(|block| block["text"].as_str())
+        .collect::<String>();
+    (!text.is_empty()).then_some(text)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor as IoCursor;
+
+    use super::{Cursor, parse_models, read_events};
+    use crate::harness::RunOptions;
+
+    #[test]
+    fn command_is_ask_mode_and_appends_instructions() {
+        let harness = Cursor {
+            program: "cursor-agent".into(),
+        };
+        let command = harness.command(
+            "why is this failing",
+            None,
+            &RunOptions {
+                model: Some("cursor-grok-4.6-high-fast"),
+                reasoning: None,
+                instructions: Some("Be concise."),
+            },
+        );
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy())
+            .collect::<Vec<_>>();
+
+        assert!(args.windows(2).any(|args| args == ["--mode", "ask"]));
+        assert!(
+            args.windows(2)
+                .any(|args| args == ["--output-format", "stream-json"])
+        );
+        assert!(
+            args.windows(2)
+                .any(|args| args == ["--model", "cursor-grok-4.6-high-fast"])
+        );
+        assert_eq!(
+            args.last().map(|arg| arg.as_ref()),
+            Some("why is this failing\n\nBe concise.")
+        );
+    }
+
+    #[test]
+    fn command_resumes_with_saved_session() {
+        let harness = Cursor {
+            program: "cursor-agent".into(),
+        };
+        let command = harness.command(
+            "hello",
+            Some("session-1"),
+            &RunOptions {
+                model: None,
+                reasoning: None,
+                instructions: None,
+            },
+        );
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy())
+            .collect::<Vec<_>>();
+
+        assert!(
+            args.windows(2)
+                .any(|args| args == ["--resume", "session-1"])
+        );
+    }
+
+    #[test]
+    fn parses_model_table() {
+        let models = parse_models(concat!(
+            "Available models\n",
+            "\n",
+            "auto - Auto (default)\n",
+            "cursor-grok-4.6-high-fast - Cursor Grok 4.6 Fast\n",
+            "gpt-5.2 - GPT-5.2\n",
+        ))
+        .unwrap();
+
+        assert_eq!(models.len(), 3);
+        assert_eq!(models[0].id, "auto");
+        assert_eq!(models[0].name, "Auto");
+        assert!(models[0].is_default);
+        assert_eq!(models[1].id, "cursor-grok-4.6-high-fast");
+        assert_eq!(models[1].name, "Cursor Grok 4.6 Fast");
+        assert!(!models[1].is_default);
+    }
+
+    #[test]
+    fn streams_partials_and_uses_the_complete_message() {
+        let input = concat!(
+            "{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"s-1\"}\n",
+            "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"hel\"}]},\"session_id\":\"s-1\",\"timestamp_ms\":1}\n",
+            "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"lo\"}]},\"session_id\":\"s-1\",\"timestamp_ms\":2}\n",
+            "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]},\"session_id\":\"s-1\"}\n",
+            "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"result\":\"hello\",\"session_id\":\"s-1\",\"request_id\":\"r-1\"}\n"
+        );
+        let mut streamed = String::new();
+        let response = read_events(IoCursor::new(input), &mut |delta| {
+            streamed.push_str(delta);
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(streamed, "hello");
+        assert_eq!(response.answer, "hello");
+        assert_eq!(response.session_id, "s-1");
+    }
+
+    #[test]
+    fn falls_back_to_result_text_without_a_complete_message() {
+        let input = concat!(
+            "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"par\"}]},\"session_id\":\"s-1\",\"timestamp_ms\":1}\n",
+            "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"result\":\"partial\",\"session_id\":\"s-1\"}\n"
+        );
+        let response = read_events(IoCursor::new(input), &mut |_| Ok(())).unwrap();
+        assert_eq!(response.answer, "partial");
+    }
+
+    #[test]
+    fn surfaces_reported_errors() {
+        let input = "{\"type\":\"result\",\"subtype\":\"error\",\"is_error\":true,\"result\":\"rate limited\",\"session_id\":\"s-1\"}\n";
+        let error = read_events(IoCursor::new(input), &mut |_| Ok(())).unwrap_err();
+        assert_eq!(error.message(), "Cursor reported an error: rate limited");
+    }
+}

--- a/src/harness/grok.rs
+++ b/src/harness/grok.rs
@@ -1,0 +1,340 @@
+use std::ffi::OsString;
+use std::io::{BufRead, BufReader, Read};
+use std::process::{Command, Stdio};
+
+use serde_json::Value;
+
+use super::{Harness, Model, ReasoningLevel, Response, RunOptions};
+use crate::error::{Error, Result};
+
+const REASONING_LEVELS: &[(&str, &str)] = &[
+    ("minimal", "Least reasoning"),
+    ("low", "Low reasoning"),
+    ("medium", "Balanced reasoning"),
+    ("high", "Deep reasoning"),
+];
+
+pub(super) struct Grok {
+    program: OsString,
+}
+
+impl Grok {
+    pub(super) fn new(program: OsString) -> Self {
+        Self { program }
+    }
+
+    fn command(
+        &self,
+        question: &str,
+        session_id: Option<&str>,
+        options: &RunOptions<'_>,
+    ) -> Command {
+        let mut command = Command::new(&self.program);
+        command.args([
+            "-p",
+            question,
+            "--output-format",
+            "streaming-json",
+            "--permission-mode",
+            "plan",
+            "--no-auto-update",
+        ]);
+        if let Some(session_id) = session_id {
+            command.args(["--resume", session_id]);
+        }
+        if let Some(model) = options.model {
+            command.args(["--model", model]);
+        }
+        if let Some(reasoning) = options.reasoning {
+            command.args(["--reasoning-effort", reasoning]);
+        }
+        if let Some(instructions) = options.instructions {
+            command.args(["--rules", instructions]);
+        }
+        command
+    }
+}
+
+impl Harness for Grok {
+    fn models(&mut self) -> Result<Vec<Model>> {
+        let output = Command::new(&self.program)
+            .arg("models")
+            .output()
+            .map_err(start_error)?;
+        if !output.status.success() {
+            return Err(Error::agent(
+                "grok",
+                format!(
+                    "could not list Grok models: {}",
+                    String::from_utf8_lossy(&output.stderr).trim()
+                ),
+            ));
+        }
+        let output = String::from_utf8(output.stdout).map_err(|_| {
+            Error::agent(
+                "grok",
+                "Grok returned a model list that was not valid UTF-8",
+            )
+        })?;
+        parse_models(&output)
+    }
+
+    fn ask(
+        &mut self,
+        question: &str,
+        session_id: Option<&str>,
+        options: RunOptions<'_>,
+        on_delta: &mut dyn FnMut(&str) -> Result<()>,
+    ) -> Result<Response> {
+        let mut child = self
+            .command(question, session_id, &options)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(start_error)?;
+        let stdout = child.stdout.take().expect("piped stdout is available");
+        let mut stderr = child.stderr.take().expect("piped stderr is available");
+        let stderr_reader = std::thread::spawn(move || {
+            let mut output = Vec::new();
+            let _ = stderr.read_to_end(&mut output);
+            output
+        });
+
+        let result = read_events(BufReader::new(stdout), on_delta);
+        let status = child
+            .wait()
+            .map_err(|error| Error::agent("grok", format!("could not wait for Grok: {error}")))?;
+        let stderr = stderr_reader
+            .join()
+            .map_err(|_| Error::agent("grok", "could not read Grok error output"))?;
+
+        if !status.success() && result.is_err() {
+            return Err(failure(status, &stderr));
+        }
+        result
+    }
+}
+
+fn start_error(error: std::io::Error) -> Error {
+    if error.kind() == std::io::ErrorKind::NotFound {
+        Error::new(
+            "Grok is not installed or not on PATH",
+            "install it with 'curl -fsSL https://x.ai/cli/install.sh | bash' and run 'grok login'",
+        )
+    } else {
+        Error::agent("grok", format!("could not start Grok: {error}"))
+    }
+}
+
+fn failure(status: std::process::ExitStatus, stderr: &[u8]) -> Error {
+    let detail = String::from_utf8_lossy(stderr).trim().to_owned();
+    if detail.is_empty() {
+        Error::agent("grok", format!("Grok exited with {status}"))
+    } else {
+        Error::agent("grok", format!("Grok failed: {detail}"))
+    }
+}
+
+fn parse_models(output: &str) -> Result<Vec<Model>> {
+    let reasoning = REASONING_LEVELS
+        .iter()
+        .map(|(id, description)| ReasoningLevel {
+            id: (*id).to_owned(),
+            description: (*description).to_owned(),
+        })
+        .collect::<Vec<_>>();
+    let mut models = Vec::new();
+    let mut in_available = false;
+
+    for line in output.lines() {
+        let line = line.trim();
+        if line.starts_with("Available models") {
+            in_available = true;
+            continue;
+        }
+        if !in_available {
+            continue;
+        }
+        let Some(entry) = line.strip_prefix('*').or_else(|| line.strip_prefix('-')) else {
+            continue;
+        };
+        let entry = entry.trim();
+        let Some(id) = entry.split_whitespace().next() else {
+            continue;
+        };
+        models.push(Model {
+            id: id.to_owned(),
+            name: id.to_owned(),
+            description: "xAI Grok".to_owned(),
+            is_default: entry.contains("(default)"),
+            reasoning: reasoning.clone(),
+            default_reasoning: None,
+        });
+    }
+
+    if models.is_empty() {
+        Err(Error::agent(
+            "grok",
+            "Grok did not report any available models",
+        ))
+    } else {
+        Ok(models)
+    }
+}
+
+fn read_events(
+    reader: impl BufRead,
+    on_delta: &mut dyn FnMut(&str) -> Result<()>,
+) -> Result<Response> {
+    let mut answer = String::new();
+    let mut session_id = None;
+    let mut reported_error = None;
+
+    for line in reader.lines() {
+        let line = line.map_err(|error| {
+            Error::agent("grok", format!("could not read Grok response: {error}"))
+        })?;
+        let event: Value = serde_json::from_str(&line).map_err(|error| {
+            Error::agent("grok", format!("could not parse Grok response: {error}"))
+        })?;
+        match event.get("type").and_then(Value::as_str) {
+            Some("text") => {
+                if let Some(delta) = event.get("data").and_then(Value::as_str) {
+                    answer.push_str(delta);
+                    on_delta(delta)?;
+                }
+            }
+            Some("error") => {
+                reported_error = event
+                    .get("message")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned);
+            }
+            Some("end") => {
+                session_id = event
+                    .get("session_id")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned);
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    if let Some(error) = reported_error {
+        return Err(Error::agent(
+            "grok",
+            format!("Grok reported an error: {error}"),
+        ));
+    }
+    Ok(Response {
+        answer: if answer.is_empty() {
+            return Err(Error::agent(
+                "grok",
+                "Grok completed without returning an answer",
+            ));
+        } else {
+            answer
+        },
+        session_id: session_id
+            .ok_or_else(|| Error::agent("grok", "Grok completed without returning a session ID"))?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::{Grok, parse_models, read_events};
+    use crate::harness::RunOptions;
+
+    #[test]
+    fn command_is_read_only_and_resumes_sessions() {
+        let harness = Grok {
+            program: "grok".into(),
+        };
+        let command = harness.command(
+            "hello",
+            Some("session-1"),
+            &RunOptions {
+                model: Some("grok-4.6"),
+                reasoning: Some("high"),
+                instructions: Some("Be concise."),
+            },
+        );
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy())
+            .collect::<Vec<_>>();
+
+        assert!(
+            args.windows(2)
+                .any(|args| args == ["--permission-mode", "plan"])
+        );
+        assert!(
+            args.windows(2)
+                .any(|args| args == ["--resume", "session-1"])
+        );
+        assert!(args.windows(2).any(|args| args == ["--model", "grok-4.6"]));
+        assert!(
+            args.windows(2)
+                .any(|args| args == ["--reasoning-effort", "high"])
+        );
+        assert!(
+            args.windows(2)
+                .any(|args| args == ["--rules", "Be concise."])
+        );
+    }
+
+    #[test]
+    fn parses_model_table() {
+        let models = parse_models(concat!(
+            "You are not authenticated.\n",
+            "\n",
+            "Default model: grok-4.6\n",
+            "\n",
+            "Available models:\n",
+            "  * grok-4.6 (default)\n",
+            "  - grok-4.5\n",
+        ))
+        .unwrap();
+
+        assert_eq!(models.len(), 2);
+        assert_eq!(models[0].id, "grok-4.6");
+        assert!(models[0].is_default);
+        assert_eq!(models[0].reasoning.len(), 4);
+        assert_eq!(models[1].id, "grok-4.5");
+        assert!(!models[1].is_default);
+    }
+
+    #[test]
+    fn streams_text_and_extracts_the_session() {
+        let input = concat!(
+            "{\"type\":\"text\",\"data\":\"hel\"}\n",
+            "{\"type\":\"text\",\"data\":\"lo\"}\n",
+            "{\"type\":\"usage\",\"messageId\":\"m-1\"}\n",
+            "{\"type\":\"end\",\"stop_reason\":\"stop\",\"session_id\":\"session-1\",\"request_id\":\"r-1\"}\n"
+        );
+        let mut streamed = String::new();
+        let response = read_events(Cursor::new(input), &mut |delta| {
+            streamed.push_str(delta);
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(streamed, "hello");
+        assert_eq!(response.answer, "hello");
+        assert_eq!(response.session_id, "session-1");
+    }
+
+    #[test]
+    fn surfaces_reported_errors() {
+        let input = concat!(
+            "{\"type\":\"text\",\"data\":\"partial\"}\n",
+            "{\"type\":\"error\",\"message\":\"rate limited\"}\n",
+            "{\"type\":\"end\",\"stop_reason\":\"error\",\"session_id\":\"session-1\"}\n"
+        );
+        let error = read_events(Cursor::new(input), &mut |_| Ok(())).unwrap_err();
+        assert_eq!(error.message(), "Grok reported an error: rate limited");
+    }
+}

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -1,5 +1,7 @@
 mod claude;
 mod codex;
+mod cursor;
+mod grok;
 mod opencode;
 mod pi;
 
@@ -135,6 +137,31 @@ pub static DEFINITIONS: &[Definition] = &[
         program_env: "ASK_PI_BIN",
         create: |program| Box::new(pi::Pi::new(program)),
     },
+    Definition {
+        id: "cursor",
+        aliases: &["cursor-agent"],
+        name: "Cursor",
+        description: "Cursor Agent CLI",
+        default_model: None,
+        default_reasoning: None,
+        reasoning: ReasoningControl::Managed {
+            label: "Managed by Cursor",
+            explanation: "Cursor manages model selection and reasoning for its supported models.",
+        },
+        program_env: "ASK_CURSOR_BIN",
+        create: |program| Box::new(cursor::Cursor::new(program)),
+    },
+    Definition {
+        id: "grok",
+        aliases: &["grok-cli"],
+        name: "Grok",
+        description: "xAI Grok Build",
+        default_model: None,
+        default_reasoning: None,
+        reasoning: ReasoningControl::Selectable,
+        program_env: "ASK_GROK_BIN",
+        create: |program| Box::new(grok::Grok::new(program)),
+    },
 ];
 
 pub fn find(name: &str) -> Option<&'static Definition> {
@@ -203,6 +230,10 @@ mod tests {
         assert_eq!(resolve("codex").unwrap().id, "codex");
         assert_eq!(resolve("claude-code").unwrap().id, "claude");
         assert_eq!(resolve("open-code").unwrap().id, "opencode");
+        assert_eq!(resolve("cursor").unwrap().id, "cursor");
+        assert_eq!(resolve("cursor-agent").unwrap().id, "cursor");
+        assert_eq!(resolve("grok").unwrap().id, "grok");
+        assert_eq!(resolve("grok-cli").unwrap().id, "grok");
         assert!(resolve("missing").is_err());
     }
 }

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -69,12 +69,13 @@ pub struct Definition {
     pub default_reasoning: Option<&'static str>,
     pub reasoning: ReasoningControl,
     program_env: &'static str,
+    default_program: &'static str,
     create: fn(OsString) -> Box<dyn Harness>,
 }
 
 impl Definition {
     fn program(&self) -> OsString {
-        std::env::var_os(self.program_env).unwrap_or_else(|| self.id.into())
+        std::env::var_os(self.program_env).unwrap_or_else(|| self.default_program.into())
     }
 
     pub fn is_available(&self) -> bool {
@@ -96,6 +97,7 @@ pub static DEFINITIONS: &[Definition] = &[
         default_reasoning: Some("low"),
         reasoning: ReasoningControl::Selectable,
         program_env: "ASK_CODEX_BIN",
+        default_program: "codex",
         create: |program| Box::new(codex::Codex::new(program)),
     },
     Definition {
@@ -110,6 +112,7 @@ pub static DEFINITIONS: &[Definition] = &[
             explanation: "Claude Code manages reasoning automatically for its selected model.",
         },
         program_env: "ASK_CLAUDE_BIN",
+        default_program: "claude",
         create: |program| Box::new(claude::Claude::new(program)),
     },
     Definition {
@@ -124,6 +127,7 @@ pub static DEFINITIONS: &[Definition] = &[
             explanation: "OpenCode manages reasoning through model-specific variants.",
         },
         program_env: "ASK_OPENCODE_BIN",
+        default_program: "opencode",
         create: |program| Box::new(opencode::OpenCode::new(program)),
     },
     Definition {
@@ -135,6 +139,7 @@ pub static DEFINITIONS: &[Definition] = &[
         default_reasoning: None,
         reasoning: ReasoningControl::Selectable,
         program_env: "ASK_PI_BIN",
+        default_program: "pi",
         create: |program| Box::new(pi::Pi::new(program)),
     },
     Definition {
@@ -149,6 +154,7 @@ pub static DEFINITIONS: &[Definition] = &[
             explanation: "Cursor manages model selection and reasoning for its supported models.",
         },
         program_env: "ASK_CURSOR_BIN",
+        default_program: "cursor-agent",
         create: |program| Box::new(cursor::Cursor::new(program)),
     },
     Definition {
@@ -160,6 +166,7 @@ pub static DEFINITIONS: &[Definition] = &[
         default_reasoning: None,
         reasoning: ReasoningControl::Selectable,
         program_env: "ASK_GROK_BIN",
+        default_program: "grok",
         create: |program| Box::new(grok::Grok::new(program)),
     },
 ];
@@ -231,6 +238,7 @@ mod tests {
         assert_eq!(resolve("claude-code").unwrap().id, "claude");
         assert_eq!(resolve("open-code").unwrap().id, "opencode");
         assert_eq!(resolve("cursor").unwrap().id, "cursor");
+        assert_eq!(resolve("cursor").unwrap().default_program, "cursor-agent");
         assert_eq!(resolve("cursor-agent").unwrap().id, "cursor");
         assert_eq!(resolve("grok").unwrap().id, "grok");
         assert_eq!(resolve("grok-cli").unwrap().id, "grok");


### PR DESCRIPTION
Adds two new harnesses to the existing Codex / Claude Code / OpenCode / Pi set.

## Cursor
- Spawns `cursor-agent` (env override: `ASK_CURSOR_BIN`, e.g. `cursor-work-agent`)
- Read-only: `--mode ask` (Q&A mode makes no edits), `--trust` for headless runs
- Streams `stream-json` partials with `--stream-partial-output`; final untimestamped assistant message is the answer, `result` event carries the session ID
- Session resume via `--resume <chat_id>`
- `models()` parses the `cursor-agent models` table (auto, composer family, codex, cursor-grok, opus, etc.)

## Grok
- Spawns `grok` (env override: `ASK_GROK_BIN`), xAI Grok Build CLI
- Read-only: `--permission-mode plan`, plus `--no-auto-update` for scripts
- Parses `streaming-json` NDJSON events (`text` deltas, `error`, terminal `end` with `session_id`)
- Session resume via `--resume <session_id>`
- Models from `grok models`; hardcoded xAI reasoning effort levels (minimal/low/medium/high) since the CLI reports none

## Notes
- Both CLIs install a binary named `agent`; ask calls the unambiguous `cursor-agent` name for Cursor so the two never collide
- Grok's streaming-json event schema was verified against the xai-org/grok-build source; the Cursor harness was live-tested end-to-end (one-shot, continue, session list)
- `cargo fmt --check`, `cargo test --locked`, `cargo clippy --locked --all-targets -- -D warnings` all pass (89 tests)